### PR TITLE
remove reference to /var/spool/cwl

### DIFF
--- a/scripts/run_biasfilter.sh
+++ b/scripts/run_biasfilter.sh
@@ -3,6 +3,6 @@
 set -e
 
 echo "python /usr/local/bin/biasFilter.py $1 --mapq=1 --baseq=1 --tempFolder=/var/spool/cwl/ $2 $3 $4 /var/spool/cwl/filtered.vcf"
-python /usr/local/bin/biasFilter.py $1 --mapq=1 --baseq=1 --tempFolder=/var/spool/cwl/ $2 $3 $4 /var/spool/cwl/filtered.vcf
-mkdir -p /var/spool/cwl/filtered_qcSummary
+python /usr/local/bin/biasFilter.py $1 --mapq=1 --baseq=1 --tempFolder=${TMPDIR} $2 $3 $4 ${PWD}/filtered.vcf
+mkdir -p ${PWD}/filtered_qcSummary
 


### PR DESCRIPTION
"/var/spool/cwl" is not part of the CWL standard and is non-portable, see https://github.com/common-workflow-language/common-workflow-language/issues/674